### PR TITLE
Add addon.json information.

### DIFF
--- a/docs/add-on-structure.md
+++ b/docs/add-on-structure.md
@@ -66,14 +66,141 @@ add-on and display information about it in the Admin CP. At minimum, your `addon
 {
     "title": "My Add-on by Some Company",
     "version_string": "2.0.0",
-    "version_id": 2000070
+    "version_id": 2000070,
+    "dev": "Some Company"
 }
 ```
 
-A basic file will be created for you automatically when creating the add-on. It supports a lot more besides the example 
-above, but we'll go into that in more detail later.
+A basic file will be created for you automatically when creating the add-on.
 
-Including this file is mandatory.
+Including a valid `addon.json` file is mandatory for your addon to be recognized but you can always [validate your addon.json file](../development-tools/#validate-your-addonjson-file).
+
+#### Properties
+<table>
+<thead>
+<th>Property</th>
+<th>Description</th>
+</thead>
+<tbody>
+<tr>
+<td><code>legacy_addon_id</code></td>
+<td>Used to enable automatic handling of addon ID changes when upgrading from XenForo 1 to XenForo 2.</td>
+</tr>
+
+<tr>
+<td><code>title</code></td>
+<td>The title of the addon. This will show in the Admin Panel.</td>
+</tr>
+
+<tr>
+<td><code>description</code></td>
+<td>A description of the addon. This will show in the Admin Panel.</td>
+</tr>
+
+<tr>
+<td><code>version_id</code></td>
+<td>The internal ID used by XenForo to track updates to your addon. This must be incremented every release.</td>
+</tr>
+
+<tr>
+<td><code>version_string</code></td>
+<td>The human-readable addon version. This will show in the Admin Panel instead of the <code>version_id</code> property.</td>
+</tr>
+
+<tr>
+<td><code>dev</code></td>
+<td>The name of the developer of the addon. This will show in the Admin Panel.</td>
+</tr>
+
+<tr>
+<td><code>dev_url</code></td>
+<td>If set, the developer's name will show in the Admin Panel as a hyperlink, with this as the target (href).</td>
+</tr>
+
+<tr>
+<td><code>faq_url</code></td>
+<td>If set, an FAQ hyperlink will show in the Admin Panel, with this as the target (href).</td>
+</tr>
+
+<tr>
+<td><code>support_url</code></td>
+<td>If set, a support hyperlink will show in the Admin Panel, with this as the target (href).</td>
+</tr>
+
+<tr>
+<td><code>extra_urls</code></td>
+<td>This allows you to display links to other things related to the add-on (perhaps a bug reports link, a manual - whatever you like).<br>An array of JSON objects, where the key is the link text and the value is the link target (href).</td>
+</tr>
+
+<tr>
+<td><code>require</code></td>
+<td>A set of requirements that need to be met for XenForo to allow installation of the addon. See <a href="#the-requirements-property">'The requirements property'</a> for more information.</td>
+</tr>
+
+<tr>
+<td><code>icon</code></td>
+<td>The icon of the resource. This can be a Font Awesome icon name (e.g. <code>fa-shopping-bag</code>, or the path to an image file.)</td>
+</tr>
+
+</tbody>
+</table>
+
+##### The requirements property
+The require property is the standard way of blocking an add-on install or upgrade if the environment doesn't support or meet the requirements.  
+You can use it to require other add-ons to be installed first, certain PHP extensions to be present or enabled and/or to enforce a minimum PHP version.
+
+Here's an example snippet:
+```json
+...
+  "require": {
+      "XF": [2000010, "XenForo 2.0.0+"],
+      "php": ["5.4.0", "PHP 5.4.0+"],
+      "php-ext/json": ["*", "JSON extension"]
+  }
+...
+```
+
+Each requirement, is a named array:
+
+- The name of the array is the product ID (e.g. `XF` or `php`).  
+- The first array element is the version of the product (e.g. `2000010` or `5.4.0`). You can use use `*` to refer to any version of the product.  
+- The second element is the human-readable text of that requirement and this is what's used in messages (e.g. `XenForo 2.0.0+` or `PHP 5.4.0+`).
+
+Here's a summary of the supported product IDs:
+<table>
+<thead>
+<th>Product/Requirement Name</th>
+<th>Refers to...</th>
+<th>Value</th>
+</thead>
+<tbody>
+
+<tr>
+<td><code>XF</code></td>
+<td>The XenForo installation version.</td>
+<td>The XenForo version ID, for example <code>200010</code>.<br>You can get your current XenForo version by checking the  top of the <code>/src/XF.php</code> file for the <code>$versionId</code> definion or by printing the value of <code>\XF::$versionId</code>.</td>
+</tr>
+
+<tr>
+<td><code>php</code></td>
+<td>The PHP version.</td>
+<td>The PHP version, for example <code>5.4.0</code>.<br>It's recommended that you keep this as low as possible; updating a PHP version can be quite a complex task - especially if other add-ons conflict with newer PHP versions.</td>
+</tr>
+
+<tr>
+<td><code>php-ext/(extension name)</code></td>
+<td>A PHP extension - where <code>(extension name)</code> is the name of the extension.</td>
+<td>The PHP extension version.<br>This is checked using the PHP <code>version_compare</code> function, so it even works for version strings in the official full PHP format like <code>7.1.19-1+ubuntu16.04.1+deb.sury.org+1</code>.</td>
+</tr>
+
+<tr>
+<td><code>(any addon ID)</code></td>
+<td>Any XenForo addon such as <code>Demo/Addon</code>.<br>If you're unsure about an addon's ID, check it's <code>addon.json</code> file.</td>
+<td>The addon version ID.<br>You can refer to the <a href="#recommended-version-id-format">Recommended version ID format</a> for more information.</td>
+</tr>
+
+</tbody>
+</table>
 
 ### hashes.json file
 

--- a/docs/lets-build-an-add-on.md
+++ b/docs/lets-build-an-add-on.md
@@ -11,23 +11,22 @@ Throughout the add-on we will use the add-on ID of `Demo/Portal`. The first thin
 
     **Enter an ID for this add-on:** Demo/Portal
 
-    **Enter a title:** Demo/Portal
+    **Enter a title:** Demo - Portal
 
-    **Enter a version ID:** 1000010
+    **Enter a version ID:** This integer will be used for internal variable comparisons.  
+    Each release of your addon should increase this number:  1000010
 
-    ** Version string set to: 1.0.0 Alpha **
+    Version string set to: 1.0.0 Alpha
 
-    **Should this add-on be enabled? (y/n)** y
+    **Does this add-on supersede a XenForo 1 add-on? (y/n)** n
 
-    **Add-on created successfully. Should the addon.json file be written out to ../src/addons/Demo/Portal/addon.json? (y/n)** y
-
-    **The addon.json file was successfully written out to ../src/addons/Demo/Portal/addon.json**
+    The addon.json file was successfully written out to /var/www/src/addons/Demo/Portal/addon.json
 
     **Does your add-on need a Setup file? (y/n)** y
 
     **Does your Setup need to support running multiple steps? (y/n)** y
 
-    **The Setup.php file was successfully written out to ../src/addons/Demo/Portal/Setup.php**
+    The Setup.php file was successfully written out to /var/www/src/addons/Demo/Portal/Setup.php
 
 The add-on has now been created, you will now find that you have a new directory in the `src/addons` directory, and you will find the add-on in the "Installed add-ons" list of the Admin CP.
 
@@ -35,26 +34,43 @@ One of the files that has been created is the `addon.json` file, which currently
 
 ```json
 {
+    "legacy_addon_id": "",
     "title": "Demo - Portal",
+    "description": "",
+    "version_id": 1000010,
     "version_string": "1.0.0 Alpha",
-    "version_id": 1000010
+    "dev": "",
+    "dev_url": "",
+    "faq_url": "",
+    "support_url": "",
+    "extra_urls": [],
+    "require": [],
+    "icon": ""
 }
 ```
 
-Let's expand on that a little bit:
+Let's fill in some of these details:
 
 ```json
 {
+    "legacy_addon_id": "",
     "title": "Demo - Portal",
     "description": "Add-on which will display featured threads on the forum home page.",
-    "version_string": "1.0.0 Alpha",
     "version_id": 1000010,
+    "version_string": "1.0.0 Alpha",
     "dev": "You!",
-    "icon": "fa-code"
+    "dev_url": "",
+    "faq_url": "",
+    "support_url": "",
+    "extra_urls": [],
+    "require": [],
+    "icon": "fa-home"
 }
 ```
 
-This is still pretty basic, but we have now added a description, the developer's name and specified that we want to display an icon. The icon can either be a path (relative to your add-on root) or the name of a [FontAwesome icon](http://fontawesome.io/icons/) as we've done here.
+We have now added a `description`, the developer's name (`dev`) and specified that we want to display an icon (`icon`). The icon can either be a path (relative to your add-on root) or the name of a [Font Awesome icon](http://fontawesome.io/icons/) as we've done here.
+
+As we're not superceding a XenForo 1 addon, we can disregard `legacy_addon_id`. For a full explaination of all of the properties in the `addon.json` file, refer to the [Add-on structure section](../add-on-structure/#addonjson-file).
 
 ## Creating the Setup class
 

--- a/docs/template-syntax.md
+++ b/docs/template-syntax.md
@@ -153,9 +153,35 @@ The else and else-if tags are used in conjunction with the if tag to conditional
 
 As you can see, once a condition has been met, the rest of the if statement is ignored. (So, in this case, if the user is an Administrator, the top `xf:if` section is run but then the rest of the if statement is ignored.)
 
-### ForEach tag
+### For-each tag
 
+The for-each tag allows you to loop over an array of items, printing a block of HTML for each item.
 
+```html
+<xf:set var="$names" value="{{ ['Patrick', 'Theresa', 'Kimball', 'Wayne', 'Grace'] }}" />
+
+<xf:foreach loop="$names" value="$name" i="$i">
+	<p>Hello there, {$name}. This is name number {$i}.</p>
+</xf:foreach>
+```
+
+The for-each tag takes the following attributes:
+
+- `loop` - The array to loop over.
+- `value` - A variable name to use within the loop, containing the current array item.
+- `i` -  A variable name to use in the loop for the current index.
+
+#### Example Output
+
+> Hello there, Patrick. This is name number 1.
+>
+> Hello there, Theresa. This is name number 2.
+>
+> Hello there, Kimball. This is name number 3.
+>
+> Hello there, Wayne. This is name number 4.
+>
+> Hello there, Grace. This is name number 5.
 
 ## Template tags
 

--- a/docs/template-syntax.md
+++ b/docs/template-syntax.md
@@ -1,12 +1,12 @@
 The XenForo 2 template syntax is a powerful tool for both developers and forum administrators, giving you complete control over the layout of your XenForo pages.
 
-### Best practices
+## Best practices
 - XenForo tags, by convention, are `lowercase`.
 - All XenForo tags are prefixed with the `xf:` namespace.
 
-### Useful information
+## Useful information
 
-#### Commenting up your templates
+### Commenting up your templates
 If you want to comment out some template code (or an inspirational message) that you don't want viewable in the final page source, you can use the `xf:comment` tag.
 
 ```html
@@ -17,7 +17,19 @@ you will find a great deal more peace in your life.
 </xf:comment>
 ```
 
-### Template macros
+### Including another template in a template
+
+The `xf:include` tag allows you to include a different template in your current template.
+
+```html
+<xf:include template="my_template" />
+```
+
+Simply set the `template  ` attribute to the name of the template you want to include.
+
+
+
+## Template macros
 Template macros are a very powerful aspect of the XenForo template syntax.
 
 You should generally use a macro any place you would use a function or subroutine in a programming language.
@@ -26,7 +38,7 @@ For non-programmers, I'd summarize this as: **either** use a macro any place you
 !!! warning
 	For readability reasons, you should not use a macro tag as a variable. You should instead use the Set tag and treat the variable as you would any template variable.
 
-#### Defining a macro
+### Defining a macro
 ```html
 <xf:macro
     name="my_macro_name">
@@ -40,7 +52,7 @@ At its simplest, a macro can be defined with a `name` attribute and the content 
 !!! note
 	When you're using a macro in multiple files, it's best practice to put the macro in it's own template.
 
-##### Macro arguments
+#### Macro arguments
 ```html
 <xf:macro
     name="my_macro_name"
@@ -56,7 +68,7 @@ This value would be overridden if the macro was called with the message argument
 
 Sometimes it's necessary to mark an argument as required. This can be done by setting the argument value to `!` in the macro definition.
 
-#### Including & using macros
+### Including & using macros
 ```html
 <xf:macro template="my_macro_template" name="my_macro_name" />
 ```
@@ -65,7 +77,7 @@ At it's simplest, you include a macro by setting the `name` attribute and leavin
 !!! note
 	When using a macro tag, you should use the self-closing form of the tag to allow someone to more easily distinguish the difference between a definition and usage of a macro.
 
-##### Macro arguments
+#### Macro arguments
 You can also provide arguments to the macro:
 
 ```html
@@ -77,12 +89,83 @@ Where `argName` is the name of the macro argument.
 !!! note
 	You should use `lowerCamelCase` for your macro argument names.
 
+## Template control structures
+
+The XenForo 2 template syntax supports certain control structures to make certain tasks easier to achieve.
+
+### If tag
+
+The if template tag can be used to conditionally display some HTML or a part of a template.
+
+```html
+<!-- Shows content only if a user is signed in... -->
+<xf:if is="$xf.visitor.user_id">
+	<!-- Do something... -->
+</xf:if>
+```
+
+The if tag takes the following attributes:
+
+- `is` - The condition which, when met, the tags contents should be shown.
+
+#### Conditions
+
+The `is` attribute supports a few logical operators:
+
+- `OR` - Used to link alternative conditions. (Alternatives: `||`)
+- `AND` - Used to link additional conditions. (Alternatives: `&&`)
+- `!` - Place before a condition to invert it. (Known as: 'not') 
+- `XOR` - Returns true if only one of two conditions is true. (Known as: Exclusive OR)
+
+### Else/Else-If tag
+
+The else and else-if tags are used in conjunction with the if tag to conditionally display HTML in the way that the name suggests.
+
+**Example usage of else:**
+
+```html
+<xf:if is="$xf.visitor.is_admin">
+	<!-- Content here will only be shown to Administrators... -->
+<xf:else />
+    <!-- Content here will be shown to anyone who is not an Administrator! -->
+</xf:if>
+```
+
+**Example usage of else-if:**
+
+```html
+<xf:if is="$xf.visitor.is_admin">
+    
+	<!-- Content here will only be shown to Administrators... -->
+    
+<xf:elseif is="$xf.visitor.is_moderator" />
+    <!--
+		Content here will only be shown to Moderators
+		(excluding users who are also Administrators).
+	-->
+<xf:else />
+    <!-- 
+		Content here will be shown to anyone who is not
+		an Administrator, or a Moderator.
+	-->
+</xf:if>
+```
+
+As you can see, once a condition has been met, the rest of the if statement is ignored. (So, in this case, if the user is an Administrator, the top `xf:if` section is run but then the rest of the if statement is ignored.)
+
+### ForEach tag
+
+
+
 ## Template tags
+
 ### Avatar tag
 
 Inserts a user's avatar in the page.
 
-<xf:avatar  user="{$xf.visitor}"  size="o"  canonical="true"  />
+```html
+<xf:avatar user="{$xf.visitor}" size="o" canonical="true" />
+```
 
 The avatar tag takes the following attributes:
 
@@ -107,7 +190,7 @@ If an avatar of invalid size is provided, the code will fallback to size '`s`'.
 
 Modifies the page breadcrumb.
 ```html
-<xf:breadcrumb  href="{{ link('my_page') }}">{{ phrase('my_page_name') }}</xf:breadcrumb>
+<xf:breadcrumb href="{{ link('my_page') }}">{{ phrase('my_page_name') }}</xf:breadcrumb>
 ```
 The breadcrumb tag takes the following attributes:
 
@@ -130,7 +213,7 @@ The `source` parameter essentially takes an array of objects with `href` and `va
 
 Adds a button element with the appropriate classes and optionally an icon.
 ```html
-<xf:button  icon="save"></xf:button>
+<xf:button icon="save"></xf:button>
 ```
 The button tag takes the following attributes:
 
@@ -192,7 +275,7 @@ By default, XenForo buttons support the following icons (created with CSS):
 
 Executes a PHP Callback method.
 ```html
-<xf:callback  class="Vendor\Addon\Class"  method="getX"  params="['abc']"></xf:callback>
+<xf:callback class="Vendor\Addon\Class" method="getX" params="['abc']"></xf:callback>
 ```
 The callback tag takes the following attributes:
 
@@ -231,7 +314,7 @@ For a method to be considered a callback method, it must be named appropriately 
 
 Includes a CSS or LESS template file.
 ```html
-<xf:css  src="mycss_file.css"  />
+<xf:css src="mycss_file.css"  />
 ```
 The CSS tag takes the following attributes:
 
@@ -257,7 +340,7 @@ Chris D, XenForo developer **Source**: [https://xenforo.com/community/threads/in
 
 Includes a JavaScript file.
 ```html
-<xf:js  src="myaddon/vendor/scripts/myjs_file.js"  />
+<xf:js src="myaddon/vendor/scripts/myjs_file.js"  />
 ```
 The JS tag takes the following attributes:
 
@@ -288,7 +371,7 @@ A good example of this tag is in the `editor` template.
 
 The set tag allows you to create a reference to another variable or create a new variable. You should use the set tag anywhere you would use a variable in a programming language.
 ```html
-<xf:set  var="$visitor"  value="{$xf.visitor}"  />
+<xf:set var="$visitor" value="{$xf.visitor}" />
 ```
 
 !!! warning
@@ -304,7 +387,7 @@ The set tag takes the following attributes:
 
 #### Alternative uses
 ```html
-<xf:set  var="$myVariableName">
+<xf:set var="$myVariableName">
 My Variable Value!
 This could be a callback, or simply a group of phrases.
 </xf:set>
@@ -314,6 +397,25 @@ When the `value` attribute is not provided, and the tag is not empty, the variab
 !!! warning
 	When you use the Set tag in this form, the value will be escaped and the resulting value will be a string.
 	The `value` attribute, whilst not supporting HTML or HTML-like tags does not have this limitation.
+
+### Likes tag
+
+Displays the number of likes on a post and a few of the users who've liked the post.
+
+```html
+<xf:likes content="{$post}" url="" />
+```
+
+The likes tag takes the following attributes:
+
+- `content` - The `XF\Entity\Post` or `XF\Entity\ProfilePost` entity to display the 'likes' text for.
+- `url` - The URL to display when the 'likes' text is clicked.
+
+#### Format
+
+> You, tlisbon, kcho and 2 others
+
+The format is [👍 `abc` and x others] (where the 👍 'thumbs up' emoji represents the 'likes' icon and `abc` represents the usernames of the last three users who liked the post.)
 
 ### Sidebar tag
 
@@ -337,7 +439,7 @@ Whilst the title can, of course, be hardcoded, it is **highly recommended** that
 
 Includes a widget in the page, or adds a widget to a widget position.
 ```html
-<xf:widget  key="widget_name"  />
+<xf:widget key="widget_name" />
 ```
 The widget tag takes the following attributes:
 
@@ -354,7 +456,7 @@ The widget tag takes the following attributes:
 
 Displays the status of a user, in terms of their last action and when that action occurred.
 ```html
-<xf:useractivity  user="{$xf.visitor}"  />
+<xf:useractivity user="{$xf.visitor}" />
 ```
 The UserActivity tag takes the following attributes:
 
@@ -370,7 +472,7 @@ The format is **[Activity Name]**  **· [Time]**
 
 Displays the user's banners in a horizontal list.
 ```html
-<xf:userbanners  user="{$xf.visitor}"  />
+<xf:userbanners user="{$xf.visitor}" />
 ```
 The UserBanners tag takes the following attributes:
 
@@ -386,7 +488,7 @@ An example result of the UserBanners tag.
 
 Displays a one-line summary of a user's profile.
 ```html
-<xf:userblurb  user="${xf.visitor}"  />
+<xf:userblurb user="${xf.visitor}" />
 ```
 The UserBlurb tag takes the following attributes:
 
@@ -402,7 +504,7 @@ The format is **[Role / Custom Title] · Age · Location**
 
 Displays the user's username, optionally with a tool-tip.
 ```html
-<xf:username  user="{$xf.visitor.username}"  notooltip="true"  />
+<xf:username user="{$xf.visitor.username}" notooltip="true" />
 ```
 The Username tag takes the following attributes:
 
@@ -417,7 +519,7 @@ The Username tag takes the following attributes:
 
 Displays the user's title.
 ```html
-<xf:usertitle  user="{$xf.visitor}"  />
+<xf:usertitle user="{$xf.visitor}" />
 ```
 The UserTitle tag takes the following attributes:
 


### PR DESCRIPTION
This also includes an addition to the Template syntax page: 'Template control structures'.
This resolves issue #19 .

In this commit, I've created the tables in HTML format.
If you want I can switch to Markdown format - I just added this information from an older documentation project.