### PR TITLE
Update lets-build-an-add-on.md

### DIFF
--- a/docs/lets-build-an-add-on.md
+++ b/docs/lets-build-an-add-on.md
@@ -70,7 +70,7 @@ Let's fill in some of these details:
 
 We have now added a `description`, the developer's name (`dev`) and specified that we want to display an icon (`icon`). The icon can either be a path (relative to your add-on root) or the name of a [Font Awesome icon](http://fontawesome.io/icons/) as we've done here.
 
-As we're not superceding a XenForo 1 addon, we can disregard `legacy_addon_id`. For a full explaination of all of the properties in the `addon.json` file, refer to the [Add-on structure section](../add-on-structure/#addonjson-file).
+As we're not superceding a XenForo 1 addon, we can disregard `legacy_addon_id`. For a full explaination of all of the properties in the `addon.json` file, refer to the [Add-on structure section](./add-on-structure/#addonjson-file).
 
 ## Creating the Setup class
 
@@ -96,7 +96,7 @@ class Setup extends AbstractSetup
 
 We talked a little bit already about the Setup class. We're going to be breaking the install, upgrade and uninstall processes into separate steps.
 
-Let's start by importing some useful Schema classes. If you want to learn more about them, you can refer to the [Managing the Schema section](../managing-the-schema/).  
+Let's start by importing some useful Schema classes. If you want to learn more about them, you can refer to the [Managing the Schema section](./managing-the-schema/).  
 Just after the last `use` declaration, add the following lines:
 
 ```php


### PR DESCRIPTION
updated url for links to json and schema. They all seem to be at the same level, not one level up. Unfortunately new to this md markup so I can't seem to get it to work via the preview presumably because the static site has to be built somehow. As the links are broken at the moment I don't think my edits make anything worse but they may have fixed it :)